### PR TITLE
feat(Sessions): create user sessions and persist on cookies

### DIFF
--- a/app/models/session/index.ts
+++ b/app/models/session/index.ts
@@ -1,0 +1,2 @@
+export * from './session.server'
+export * from './schema'

--- a/app/models/session/schema.ts
+++ b/app/models/session/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const SessionSchema = z.object({
+  uuid: z.string()
+})
+
+export type Session = z.infer<typeof SessionSchema>;

--- a/app/models/session/session.server.ts
+++ b/app/models/session/session.server.ts
@@ -1,0 +1,9 @@
+import * as AudiophileClient from '~/utils/audiophile-client'
+import { SessionSchema } from './schema'
+
+export const createSession = async () => {
+  const response = await AudiophileClient.sendRequest('post', 'sessions')
+  const session = SessionSchema.parse(response)
+
+  return session
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,3 @@
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import { json } from '@remix-run/node'
 import {
   Links,
@@ -11,8 +10,11 @@ import {
 } from "@remix-run/react";
 import { Footer } from '~/components'
 import { allProductCategories } from '~/models/product-category'
+import * as SessionStorage from '~/utils/session-storage'
 
 import tailwindStylesheetUrl from "./styles/tailwind.css";
+
+import type { LinksFunction, MetaFunction, LoaderArgs } from "@remix-run/node";
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: tailwindStylesheetUrl }];
@@ -24,9 +26,12 @@ export const meta: MetaFunction = () => ({
   viewport: "width=device-width,initial-scale=1",
 });
 
-export const loader = async () => {
+export const loader = async ({ request }: LoaderArgs) => {
   const categories = await allProductCategories();
-  return json({ categories })
+  const { sessionId, headers } = await SessionStorage.getOrCreateSessionId(request)
+  console.log(sessionId)
+
+  return json({ categories }, { headers })
 }
 
 export default function App() {

--- a/app/utils/session-storage/index.ts
+++ b/app/utils/session-storage/index.ts
@@ -1,0 +1,1 @@
+export * from './session-storage.server'

--- a/app/utils/session-storage/session-storage.server.ts
+++ b/app/utils/session-storage/session-storage.server.ts
@@ -1,0 +1,51 @@
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
+import invariant from "tiny-invariant";
+
+invariant(process.env.SESSION_SECRET, "SESSION_SECRET must be set");
+
+const SESSION_ID_KEY = "sessionId";
+
+const sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: "__session",
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secrets: [process.env.SESSION_SECRET],
+    secure: process.env.NODE_ENV === "production",
+  },
+});
+
+const getSession = async (request: Request) => {
+  const cookie = request.headers.get("Cookie");
+  return sessionStorage.getSession(cookie);
+}
+
+export const getSessionId = async ( request: Request ): Promise<string | undefined> => {
+  const session = await getSession(request);
+  const sessionId = session.get(SESSION_ID_KEY);
+  return sessionId;
+}
+
+interface PersistSessionParams {
+  request: Request;
+  sessionId: string;
+  redirectTo: string;
+}
+
+export const persistSession = async ({
+  request,
+  sessionId,
+  redirectTo,
+}: PersistSessionParams) => {
+  const session = await getSession(request);
+  session.set(SESSION_ID_KEY, sessionId);
+
+  return redirect(redirectTo, {
+    headers: {
+      "Set-Cookie": await sessionStorage.commitSession(session, {
+        maxAge: 60 * 60 * 24 * 7 // 7 days
+      }),
+    },
+  });
+}

--- a/app/utils/session-storage/types.ts
+++ b/app/utils/session-storage/types.ts
@@ -1,0 +1,4 @@
+export interface PersistSessionParams {
+  request: Request;
+  sessionId: string;
+}


### PR DESCRIPTION
Sessions functionality is implemented here - The API will be called to create a session record and return an identifier that will be saved in a browser cookie with 1 hour of expiration. The root's loader will check on every page load that the cookie exists, and will call the API and create a new session every time the cookie expires.

Sessions will later be used to identify the visitor and add the ability to persist some things, such as purchase carts.