### PR TITLE
fix(category banners): make whole component clickable

### DIFF
--- a/app/components/category-banner/category-banner.tsx
+++ b/app/components/category-banner/category-banner.tsx
@@ -1,11 +1,13 @@
+import { Link } from '@remix-run/react'
 import { Text, ButtonLink } from '~/components'
 import type { CategoryBannerProps } from './types'
 
 const CategoryBanner = ({ category }: CategoryBannerProps) => {
   const { name, slug, image } = category
+  const categoryPath = `/categories/${slug}`
 
   return (
-    <div className="-mt-16 flex-1 lg:-mt-20">
+    <Link className="-mt-16 flex-1 lg:-mt-20" to={categoryPath}>
       <img
           src={image.url}
           alt={`${name} icon`}
@@ -17,11 +19,11 @@ const CategoryBanner = ({ category }: CategoryBannerProps) => {
         <Text variant="body" as="h2" className="uppercase !font-bold text-center mb-3">
           { name }
         </Text>
-        <ButtonLink variant="tertiary" to={`/categories/${slug}`} className="justify-center !py-0 !px-0 mx-auto">
+        <ButtonLink variant="tertiary" to={categoryPath} className="justify-center !py-0 !px-0 mx-auto">
           Shop
         </ButtonLink>
       </div>
-    </div>
+    </Link>
   )
 }
 


### PR DESCRIPTION
Closes #26 
This PR makes the whole category banner component clickable, instead of just the `SHOP >` button. This makes it more accessible
<img width="621" alt="image" src="https://user-images.githubusercontent.com/27536621/208324034-b609315e-28e6-4345-817e-46c415f524f2.png">
