### PR TITLE
chore(ci): automate app deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: 🚀 Release
+on:
+  release:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  deploy:
+    name: 🚀 Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: 🚀 Deploy Staging
+        uses: superfly/flyctl-actions@1.3
+        with:
+          args: "deploy --config fly.toml"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Closes #27 
A GitHub action is added to deploy the app to fly.io whenever a GitHub release is created.
It will deploy to https://audiophile-stg.fly.dev/