### PR TITLE
feat(purchase carts): print only items total price instead of grand total

### DIFF
--- a/app/components/purchase-cart-list/purchase-cart-list.tsx
+++ b/app/components/purchase-cart-list/purchase-cart-list.tsx
@@ -7,7 +7,7 @@ import type { PurchaseCartListProps } from './types'
 const PurchaseCartList = ({ cart, onClose, onCartRemoval }: PurchaseCartListProps) => {
   const { items } = cart
 
-  const itemsTotalPrice = items.reduce((cumPrice, item) => item.price + cumPrice, 0)
+  const subtotal = items.reduce((cumPrice, item) => item.price + cumPrice, 0)
 
   return (
     <div className="bg-white py-8 px-7 rounded-lg relative max-w-sm mx-auto sm:ml-auto sm:mr-0">
@@ -40,11 +40,11 @@ const PurchaseCartList = ({ cart, onClose, onCartRemoval }: PurchaseCartListProp
 
       <div className="flex justify-between mb-6 items-center">
         <Text variant="body" className="!font-medium opacity-50 uppercase" as="span">
-          Total
+          Subtotal
         </Text>
 
         <Text variant="heading-6" as="span">
-          { formatCurrency(itemsTotalPrice) }
+          { formatCurrency(subtotal) }
         </Text>
       </div>
 

--- a/app/components/purchase-cart-list/purchase-cart-list.tsx
+++ b/app/components/purchase-cart-list/purchase-cart-list.tsx
@@ -5,7 +5,9 @@ import formatCurrency from '~/utils/format-currency'
 import type { PurchaseCartListProps } from './types'
 
 const PurchaseCartList = ({ cart, onClose, onCartRemoval }: PurchaseCartListProps) => {
-  const { items, total_price } = cart
+  const { items } = cart
+
+  const itemsTotalPrice = items.reduce((cumPrice, item) => item.price + cumPrice, 0)
 
   return (
     <div className="bg-white py-8 px-7 rounded-lg relative max-w-sm mx-auto sm:ml-auto sm:mr-0">
@@ -42,7 +44,7 @@ const PurchaseCartList = ({ cart, onClose, onCartRemoval }: PurchaseCartListProp
         </Text>
 
         <Text variant="heading-6" as="span">
-          { formatCurrency(total_price) }
+          { formatCurrency(itemsTotalPrice) }
         </Text>
       </div>
 


### PR DESCRIPTION
Closes #43 
The `TOTAL` shown in the cart items list is the whole order total, including extra fees like the shipping cost. This could be misleading at this point of the flow, so this PR changes that total to show only the total price of the items

![image](https://user-images.githubusercontent.com/27536621/209412164-b8e0c66f-8b31-44a3-b728-8b8b4e9b3b1c.png)
