### PR TITLE
fix(categories): Fix overlapping banners on mobile viewg

### DIFF
--- a/app/components/category-banner/category-banner.tsx
+++ b/app/components/category-banner/category-banner.tsx
@@ -7,14 +7,15 @@ const CategoryBanner = ({ category }: CategoryBannerProps) => {
   const categoryPath = `/categories/${slug}`
 
   return (
-    <Link className="-mt-16 flex-1 lg:-mt-20" to={categoryPath}>
-      <img
-          src={image.url}
-          alt={`${name} icon`}
-          className="h-32 mx-auto relative top-16 lg:h-40 lg:top-20"
-      />
-
-      <div className="bg-gray box-border pt-8 px-2 pb-6 rounded-lg">
+    <Link className="mt-16 flex-1 lg:mt-20" to={categoryPath}>
+      <div className="bg-gray box-border pt-8 px-2 pb-6 rounded-lg relative">
+        <div className="absolute -top-16 lg:-top-20 w-full text-center">
+          <img
+              src={image.url}
+              alt={`${name} icon`}
+              className="h-32 mx-auto lg:h-40"
+          />
+        </div>
         <div className="w-40 h-9 bg-black opacity-20 mx-auto rounded-[50%] blur-xl mb-6" />
         <Text variant="body" as="h2" className="uppercase !font-bold text-center mb-3">
           { name }


### PR DESCRIPTION
Closes #52 
There is an issue with the images in the categories CTAs on mobile. The image is overlapping the contiguous CTA above it, so if the user wants to click on one of the CTAs, the app really takes the user to the other category

![image](https://user-images.githubusercontent.com/27536621/209977568-d914db93-a358-4d4a-a58b-c5abdcd833cc.png)
