### PR TITLE
fix(checkout): add type="tel" attribute to confirmation code input

### DIFF
--- a/app/routes/checkout/billing-details/confirmation-code.tsx
+++ b/app/routes/checkout/billing-details/confirmation-code.tsx
@@ -80,7 +80,7 @@ export default () => {
         <Text as="p" variant="body">
           We just sent you a verification code to your email. Please enter it below
         </Text>
-        <TextInput id="code" name="code" placeholder="123456" error={errors.code} />
+        <TextInput id="code" name="code" placeholder="123456" error={errors.code} type="tel" />
         { errors.general && (
           <Text as="p" variant="body" className="text-danger !text-xs">
             { errors.general }


### PR DESCRIPTION
Closes #59 
This will allow mobile devices to pop up a numeric keyboard instead of a normal one