### PR TITLE
fix(purchase cart): dont show scrollbar if not needed

### DIFF
--- a/app/components/purchase-cart-modal/purchase-cart-modal.tsx
+++ b/app/components/purchase-cart-modal/purchase-cart-modal.tsx
@@ -7,7 +7,7 @@ const PurchaseCartModal = ({ cart, onClose, onCartRemoval }: PurchaseCartModalPr
     <div className="z-50 fixed top-0 left-0 right-0 bottom-0">
       <div className="relative h-full w-full p-6 sm:px-10">
         <div className="absolute top-0 left-0 w-full h-full -z-10 bg-black opacity-40"/>
-        <div className="max-w-6xl mx-auto mt-20 max-h-full overflow-scroll pb-20 box-border">
+        <div className="max-w-6xl mx-auto mt-20 max-h-full overflow-y-auto pb-20 box-border">
           { cart ? (
             <PurchaseCartList
               cart={cart}


### PR DESCRIPTION
Closes #69 

The `overflow:scroll` behavior added to the cart list wrapper was causing the scrollbars to be permanently visible. This looks specially bad on windows.
![image](https://user-images.githubusercontent.com/27536621/215361312-2e251cdb-6400-472f-ae3e-518d8390697a.png)

Changing the rule to `overflow-y:auto` fixes the issue, and makes the scrollbar appear only when the list is long enough, also this should be the behavior for y direction only
